### PR TITLE
Preserve round-trip output for multiline strings that need quoting

### DIFF
--- a/src/dump/dumps.rs
+++ b/src/dump/dumps.rs
@@ -18,8 +18,9 @@ use crate::{
     YAMLEncodeError,
     dump::{
         helpers::{
-            escape_double_quoted, get_decimal, has_unsafe_scalar_char, sequence_to_yaml,
-            set_to_yaml, to_yaml_float,
+            escape_double_quoted, get_decimal, has_unsafe_scalar_char,
+            needs_double_quotes_to_preserve_multiline, sequence_to_yaml, set_to_yaml,
+            to_yaml_float,
         },
         normalize::{normalize_decimal, normalize_non_utc_fraction},
     },
@@ -32,7 +33,7 @@ pub fn python_to_yaml(obj: &Bound<'_, PyAny>) -> PyResult<YamlOwned> {
     match obj {
         obj if let Ok(str) = obj.cast::<PyString>() => {
             let value = str.to_string_lossy();
-            if has_unsafe_scalar_char(&value) {
+            if has_unsafe_scalar_char(&value) || needs_double_quotes_to_preserve_multiline(&value) {
                 Ok(YamlOwned::Representation(
                     escape_double_quoted(&value),
                     ScalarStyle::DoubleQuoted,

--- a/src/dump/helpers.rs
+++ b/src/dump/helpers.rs
@@ -70,6 +70,18 @@ pub fn has_unsafe_scalar_char(value: &str) -> bool {
     })
 }
 
+pub fn needs_double_quotes_to_preserve_multiline(value: &str) -> bool {
+    if !value.contains('\n') {
+        return false;
+    }
+
+    value.ends_with('\n')
+        || value
+            .lines()
+            .find(|line| !line.is_empty())
+            .is_some_and(|line| line.starts_with([' ', '\t']))
+}
+
 pub fn escape_double_quoted(value: &str) -> String {
     let mut escaped = String::with_capacity(value.len());
     for ch in value.chars() {

--- a/tests/test_dumps.py
+++ b/tests/test_dumps.py
@@ -183,6 +183,48 @@ def test_dumps_escapes_unsafe_scalar_chars() -> None:
 
 
 @pytest.mark.parametrize(
+    "value",
+    [
+        "  indented\nnext",
+        "  indented\n  still indented",
+        "\tindented\nnext",
+    ],
+)
+def test_dumps_multiline_string_with_leading_indent_round_trips(
+    value: str,
+) -> None:
+    data = {
+        "lead": value,
+        "nested": {"lead": value},
+    }
+
+    dumped = yaml_rs.dumps(data, multiline_strings=True)
+
+    assert yaml_rs.loads(dumped) == data
+    assert pyyaml.safe_load(dumped) == data
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "\n",
+        "\n\n",
+        "line\n",
+        "line\n\n",
+    ],
+)
+def test_dumps_multiline_string_with_trailing_newline_round_trips(
+    value: str,
+) -> None:
+    data = {"value": value}
+
+    dumped = yaml_rs.dumps(data, multiline_strings=True)
+
+    assert yaml_rs.loads(dumped) == data
+    assert pyyaml.safe_load(dumped) == data
+
+
+@pytest.mark.parametrize(
     "ts",
     [ts for ts in VALID_YAMLS if ts.out_yaml is not None],
     ids=lambda ts: ts.id,


### PR DESCRIPTION
Fixes #130.

This fixes cases where `dumps(..., multiline_strings=True)` can emit literal block scalars that do not round-trip.

The PR falls back to the existing double-quoted string path for two cases:

- the first non-empty line starts with a space or tab
- the value ends with a newline

The first case is the one reported in #130. saphyr emits a literal block without an explicit indent indicator, so an indented first content line can produce invalid YAML or lose leading spaces.

The trailing-newline case is adjacent. saphyr emits `|`, but the generated document does not include the content line break other parsers need to preserve the final newline. `yaml_rs` may parse some of these back as expected, but PyYAML and ruamel do not.

I kept this local to the Python dumper rather than changing saphyr's emitter behavior.

Checks run:

- `pytest tests/test_dumps.py -q`
- `ruff check`
- `cargo +nightly fmt-nightly --check`
- `cargo +nightly clippy --all-targets --all-features`
- `maturin build --out wheel --features mimalloc`
- `typos --config .typos.toml`
- `rumdl check .`
- `zizmor .github/`